### PR TITLE
readme manager initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+<!--BEGIN_BANNER_IMAGE--><!--END_BANNER_IMAGE-->
+
 # server-sdk-kotlin
 
+<!--BEGIN_DESCRIPTION-->
 Kotlin SDK for accessing [livekit-server](https://github.com/livekit/livekit) APIs. Currently for use in JVM environments.
+<!--END_DESCRIPTION-->
 
 https://docs.livekit.io/guides/server-api/
 
@@ -90,3 +94,4 @@ System.out.println("New access token: " + token.toJwt())
 
 By default, tokens expire 6 hours after generation. You may override this by using `token.setTtl(long millis)`.
     
+<!--BEGIN_REPO_NAV--><!--END_REPO_NAV-->


### PR DESCRIPTION
This PR makes the README ready to be managed by the readme manager. It adds custom comment tags to the readme, which are invisible when the README is rendered, but tell the readme manager where to insert and update content.