### PR TITLE
Ignore unknown fields when parsing incoming webhooks

### DIFF
--- a/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
@@ -19,8 +19,8 @@ class IngressServiceClient(
     @JvmOverloads
     fun createIngress(
         name: String,
-        roomName: String,
-        participantIdentity: String,
+        roomName: String? = null,
+        participantIdentity: String? = null,
         participantName: String? = null,
         inputType: LivekitIngress.IngressInput? = LivekitIngress.IngressInput.RTMP_INPUT,
         audioOptions: LivekitIngress.IngressAudioOptions? = null,
@@ -28,8 +28,15 @@ class IngressServiceClient(
     ): Call<LivekitIngress.IngressInfo> {
         val request = with(LivekitIngress.CreateIngressRequest.newBuilder()) {
             this.name = name
-            this.participantIdentity = participantIdentity
             this.inputType = inputType
+            
+            if (roomName != null) {
+                this.roomName = roomName
+            }
+
+            if (participantIdentity != null) {
+                this.participantIdentity = participantIdentity
+            }
 
             if (participantName != null) {
                 this.participantName = participantName

--- a/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
+++ b/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
@@ -40,7 +40,7 @@ class WebhookReceiver(
         }
 
         val builder = LivekitWebhook.WebhookEvent.newBuilder()
-        JsonFormat.parser().merge(body, builder)
+        JsonFormat.parser().ignoringUnknownFields().merge(body, builder)
         return builder.build()
     }
 }


### PR DESCRIPTION


Seeing some test errors, but I don't believe these were introduced by this PR.

```
 % ./gradlew test

> Task :extractProto
proto file '/Users/davidzhao/dev/livekit/server-sdk-kotlin/protocol/livekit_analytics.proto' directly specified in configuration. It's likely you specified files('path/to/foo.proto') or fileTree('path/to/directory') in protobuf or compile configuration. This makes you vulnerable to https://github.com/google/protobuf-gradle-plugin/issues/248. Please use files('path/to/directory') instead.

> Task :compileKotlin
w: /Users/davidzhao/dev/livekit/server-sdk-kotlin/src/main/kotlin/io/livekit/server/IngressServiceClient.kt: (22, 9): Parameter 'roomName' is never used

> Task :compileJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :compileTestKotlin
w: /Users/davidzhao/dev/livekit/server-sdk-kotlin/src/test/kotlin/io/livekit/server/RoomServiceClientTest.kt: (85, 13): Variable 'response' is never used

> Task :test FAILED

EgressServiceClientTest > listEgress() FAILED
    org.opentest4j.AssertionFailedError at EgressServiceClientTest.kt:34
```