### PR TITLE
Update okhttp3 to version 4.12.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,7 +141,7 @@ val javadocJar = tasks.named<Jar>("javadocJar") {
 
 dependencies {
     protobuf(files(*protoSrc))
-    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     api("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-protobuf:2.9.0")
     implementation("com.auth0:java-jwt:4.2.1")


### PR DESCRIPTION
`okio` version `3.0.0` which is a transitive dependency of this project is being reported as vulnerable by some tools.
https://github.com/advisories/GHSA-w33c--f8w7

I did not checked if [CVE-2023-3635](https://nvd.nist.gov/vuln/detail/CVE-2023-3635) can be exploited or not.

Dependency tree:
```
\--- io.livekit:livekit-server:0.5.10
     +--- com.squareup.okhttp3:logging-interceptor:4.10.0
     |    +--- com.squareup.okhttp3:okhttp:4.10.0
     |    |    +--- com.squareup.okio:okio:3.0.0
     |    |    |    \--- com.squareup.okio:okio-jvm:3.0.0
     |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31 -> 1.7.10
     |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10
     |    |    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10
     |    |    |         |    |    \--- org.jetbrains:annotations:13.0
     |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10
     |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.10 (*)
     |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31 -> 1.7.10
     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.20 -> 1.7.10 (*)
     |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10 -> 1.7.10 (*)
     +--- com.squareup.retrofit2:converter-protobuf:2.9.0
     |    +--- com.squareup.retrofit2:retrofit:2.9.0
     |    |    \--- com.squareup.okhttp3:okhttp:3.14.9 -> 4.10.0 (*)
     |    \--- com.google.protobuf:protobuf-java:3.10.0 -> 3.21.7
     +--- com.auth0:java-jwt:4.2.1
     |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
     |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.4
     |         |    \--- com.fasterxml.jackson:jackson-bom:2.13.4
     |         |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.4 (c)
     |         |         +--- com.fasterxml.jackson.core:jackson-core:2.13.4 (c)
     |         |         \--- com.fasterxml.jackson.core:jackson-databind:2.13.4 -> 2.13.4.2 (c)
     |         +--- com.fasterxml.jackson.core:jackson-core:2.13.4
     |         |    \--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
     |         \--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
     +--- javax.annotation:javax.annotation-api:1.3.2
     +--- com.squareup.retrofit2:retrofit:2.9.0 (*)
     +--- com.google.protobuf:protobuf-java:3.21.7
     +--- com.google.protobuf:protobuf-java-util:3.21.7
     |    +--- com.google.protobuf:protobuf-java:3.21.7
     |    +--- com.google.guava:guava:31.1-android
     |    |    +--- com.google.guava:failureaccess:1.0.1
     |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
     |    |    +--- com.google.code.findbugs:jsr305:3.0.2
     |    |    +--- org.checkerframework:checker-qual:3.12.0
     |    |    +--- com.google.errorprone:error_prone_annotations:2.11.0
     |    |    \--- com.google.j2objc:j2objc-annotations:1.3
     |    +--- com.google.errorprone:error_prone_annotations:2.5.1 -> 2.11.0
     |    +--- com.google.j2objc:j2objc-annotations:1.3
     |    +--- com.google.code.findbugs:jsr305:3.0.2
     |    \--- com.google.code.gson:gson:2.8.9
     \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.10 (*)
```

The PR is updating `okhttp3` to the latest stable version.