### PR TITLE
Fix: updateIngress incorrectly sets participantIdentity to null

### DIFF
--- a/.changeset/fast-teachers-buy.md
+++ b/.changeset/fast-teachers-buy.md
@@ -1,0 +1,5 @@
+---
+"server-sdk-kotlin": patch
+---
+
+Fix: updateIngress incorrectly sets participantIdentity to null

--- a/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2025 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
@@ -119,7 +119,7 @@ class IngressServiceClient(
                 this.roomName = roomName
             }
 
-            if (participantIdentity == null) {
+            if (participantIdentity != null) {
                 this.participantIdentity = participantIdentity
             }
 


### PR DESCRIPTION
Related issue: [107](https://github.com/livekit/server-sdk-kotlin/issues/107)