### PR TITLE
Update Kotlin, Protobuf, Retrofit, Auth0 Java JWT

### DIFF
--- a/.changeset/slow-hotels-float.md
+++ b/.changeset/slow-hotels-float.md
@@ -1,0 +1,38 @@
+---
+"server-sdk-kotlin": patch
+---
+
+### Kotlin
+- **Update to Kotlin 1.9.25**  
+  Upgraded to the latest patch version for better stability and compatibility with newer tools.  
+  _Reference_: [Kotlin 1.9.25 Release Notes](https://kotlinlang.org/docs/whatsnew1920.html)
+
+---
+
+### Protobuf
+- **Update `protobufVersion` to 4.29.4**  
+  Ensures compatibility with the MySQL JDBC connector.  
+  _Note_: Previous versions had compatibility issues when working with certain database drivers.
+
+---
+
+### Retrofit
+- **Update `com.squareup.retrofit2:retrofit` to 2.11.0**
+- **Update `com.squareup.retrofit2:converter-protobuf` to 2.11.0**  
+  Fixes vulnerabilities reported in older versions of Retrofit.  
+  _Reference_: [Retrofit 2.11.0 Changelog](https://github.com/square/retrofit/blob/master/CHANGELOG.md)  
+  _Security Advisory_:
+        - [CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
+        - [CVE-2022-24329](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329)
+        - [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
+        - [CVE-2020-29582](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29582)
+        - [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)
+
+---
+
+### Auth0 Java JWT
+- **Update `com.auth0:java-jwt` to 4.5.0**  
+  Addresses security issues in earlier releases and includes bug fixes.  
+  _Reference_: [java-jwt GitHub Releases](https://github.com/auth0/java-jwt/releases)
+
+---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,8 +133,8 @@ val javadocJar = tasks.named<Jar>("javadocJar") {
 dependencies {
     protobuf(files(*protoSrc))
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
-    api("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-protobuf:2.9.0")
+    api("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-protobuf:2.11.0")
     implementation("com.auth0:java-jwt:4.2.1")
     api(protobufDep)
     api("com.google.protobuf:protobuf-java-util:$protobufVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ apply(from = "gradle/gradle-mvn-push.gradle")
 apply(plugin = "idea")
 
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.25"
     `maven-publish`
     `java-library`
     id("org.jetbrains.dokka") version "1.9.20"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ spotless {
 val protoc_platform: String? by project
 val protoSrc = File("$projectDir/protocol/protobufs/").listFiles { f -> f.isFile }
 
-val protobufVersion = "3.25.6"
+val protobufVersion = "4.29.4"
 val protobufDep = "com.google.protobuf:protobuf-java:$protobufVersion"
 protobuf {
     protoc {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,7 +135,7 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     api("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.retrofit2:converter-protobuf:2.11.0")
-    implementation("com.auth0:java-jwt:4.2.1")
+    implementation("com.auth0:java-jwt:4.5.0")
     api(protobufDep)
     api("com.google.protobuf:protobuf-java-util:$protobufVersion")
     implementation("javax.annotation:javax.annotation-api:1.3.2")


### PR DESCRIPTION
### Kotlin
- **Update to Kotlin 1.9.25**  
  Upgraded to the latest patch version for better stability and compatibility with newer tools.  
  _Reference_: [Kotlin 1.9.25 Release Notes](https://kotlinlang.org/docs/whatsnew1920.html)

### Protobuf
- **Update `protobufVersion` to 4.29.4**  
  Ensures compatibility with the MySQL JDBC connector.
  _Note_: Previous versions had compatibility issues when working with certain database drivers.
  Fixes #95

### Retrofit
- **Update `com.squareup.retrofit2:retrofit` to 2.11.0**
- **Update `com.squareup.retrofit2:converter-protobuf` to 2.11.0**  
  Fixes vulnerabilities reported in older versions of Retrofit.  
  _Reference_: [Retrofit 2.11.0 Changelog](https://github.com/square/retrofit/blob/master/CHANGELOG.md)  
  _Security Advisory_:
        - [CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
        - [CVE-2022-24329](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24329)
        - [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)
        - [CVE-2020-29582](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29582)
        - [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

### Auth0 Java JWT
- **Update `com.auth0:java-jwt` to 4.5.0**  
  Addresses security issues in earlier releases and includes bug fixes.  
  _Reference_: [java-jwt GitHub Releases](https://github.com/auth0/java-jwt/releases)