### PR TITLE
Update "com.auth0:java-jwt" to version 4.5.1

### DIFF
--- a/.changeset/eight-cycles-happen.md
+++ b/.changeset/eight-cycles-happen.md
@@ -1,0 +1,5 @@
+---
+"server-sdk-kotlin": patch
+---
+
+Update "com.auth0:java-jwt" to version 4.5.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,7 +149,7 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor")
     api("com.squareup.retrofit2:retrofit:3.0.0")
     implementation("com.squareup.retrofit2:converter-protobuf:3.0.0")
-    implementation("com.auth0:java-jwt:4.5.0")
+    implementation("com.auth0:java-jwt:4.5.1")
     api(protobufDep)
     api("com.google.protobuf:protobuf-java-util:$protobufVersion")
     implementation("javax.annotation:javax.annotation-api:1.3.2")


### PR DESCRIPTION
The current dependency tree contains a transitive dependency to `com.fasterxml.jackson.core:jackson-databind:2.15.4` which is flagged as subject to CVE-2023-35116

Tree:

```
io.livekit:livekit-server:0.12.0
     +--- com.auth0:java-jwt:4.5.0
     |    +--- com.fasterxml.jackson.core:jackson-core:2.15.4
     |    |    \--- com.fasterxml.jackson:jackson-bom:2.15.4
     |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.15.4 (c)
     |    |         +--- com.fasterxml.jackson.core:jackson-core:2.15.4 (c)
     |    |         \--- com.fasterxml.jackson.core:jackson-databind:2.15.4 (c)
     |    \--- com.fasterxml.jackson.core:jackson-databind:2.15.4
     |         +--- com.fasterxml.jackson.core:jackson-annotations:2.15.4
     |         |    \--- com.fasterxml.jackson:jackson-bom:2.15.4 (*)
     |         +--- com.fasterxml.jackson.core:jackson-core:2.15.4 (*)
     |         \--- com.fasterxml.jackson:jackson-bom:2.15.4 (*)
```

---

This PR is updating `com.auth0:java-jwt` to **4.5.1** to change the dependency tree to:

```
+--- io.livekit:livekit-server:<new version>
|    +--- com.auth0:java-jwt:4.5.1
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.0
|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.21.0
|    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.0 (c)
|    |    |         \--- com.fasterxml.jackson.core:jackson-databind:2.21.0 (c)
|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.21.0
|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.0 (*)
|    |         \--- com.fasterxml.jackson:jackson-bom:2.21.0 (*)
```
