### PR TITLE
LiveKitAPI entrypoint, ability to use a token instead of api key/secret

### DIFF
--- a/.changeset/easy-deserts-fall.md
+++ b/.changeset/easy-deserts-fall.md
@@ -1,0 +1,5 @@
+---
+"server-sdk-kotlin": minor
+---
+
+LiveKitAPI entrypoint, ability to use a token instead of api key/secret

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,6 +114,29 @@ sourceSets {
     }
 }
 
+// Generate Version.kt so the SDK version (VERSION_NAME) is available at runtime
+// for the User-Agent header. Regenerated from gradle.properties on every build.
+val generateVersionKt by tasks.registering {
+    val versionName = properties["VERSION_NAME"].toString()
+    val outputDir = layout.buildDirectory.dir("generated/source/version")
+    inputs.property("versionName", versionName)
+    outputs.dir(outputDir)
+    doLast {
+        val pkg = outputDir.get().dir("io/livekit/server").asFile
+        pkg.mkdirs()
+        pkg.resolve("Version.kt").writeText(
+            """
+            |package io.livekit.server
+            |
+            |internal const val SDK_VERSION: String = "$versionName"
+            |
+            """.trimMargin(),
+        )
+    }
+}
+
+kotlin.sourceSets.getByName("main").kotlin.srcDir(generateVersionKt)
+
 val protobufVersion = "4.29.4"
 val protobufDep = "com.google.protobuf:protobuf-java:$protobufVersion"
 protobuf {

--- a/src/main/kotlin/io/livekit/server/AgentDispatchServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/AgentDispatchServiceClient.kt
@@ -157,7 +157,7 @@ class AgentDispatchServiceClient(
                 .addInterceptor(RegionFailoverInterceptor(FailoverConfig(enabled = failover)))
                 .build()
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/AgentDispatchServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/AgentDispatchServiceClient.kt
@@ -37,6 +37,7 @@ class AgentDispatchServiceClient(
     private val service: AgentDispatchService,
     private val apiKey: String,
     private val secret: String,
+    private val token: String? = null,
 ) {
 
     /**
@@ -122,6 +123,7 @@ class AgentDispatchServiceClient(
     }
 
     private fun authHeader(vararg videoGrants: VideoGrant): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(*videoGrants)
 

--- a/src/main/kotlin/io/livekit/server/ConnectorServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/ConnectorServiceClient.kt
@@ -41,7 +41,8 @@ class ConnectorServiceClient(
     private val service: ConnectorService,
     apiKey: String,
     secret: String,
-) : ServiceClientBase(apiKey, secret) {
+    token: String? = null,
+) : ServiceClientBase(apiKey, secret, token = token) {
 
     /**
      * Dial an outbound WhatsApp call.

--- a/src/main/kotlin/io/livekit/server/ConnectorServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/ConnectorServiceClient.kt
@@ -214,7 +214,7 @@ class ConnectorServiceClient(
                 .build()
 
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
@@ -50,6 +50,7 @@ class EgressServiceClient(
     private val service: EgressService,
     private val apiKey: String,
     private val secret: String,
+    private val token: String? = null,
 ) {
 
     @JvmOverloads
@@ -704,6 +705,7 @@ class EgressServiceClient(
     }
 
     private fun authHeader(vararg videoGrants: VideoGrant): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(*videoGrants)
 

--- a/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
@@ -764,7 +764,7 @@ class EgressServiceClient(
                 .build()
 
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
@@ -241,7 +241,7 @@ class IngressServiceClient(
                 .build()
 
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/IngressServiceClient.kt
@@ -37,6 +37,7 @@ class IngressServiceClient(
     private val service: IngressService,
     private val apiKey: String,
     private val secret: String,
+    private val token: String? = null,
 ) {
     /**
      * Creates a new ingress. Default audio and video options will be used if none is provided.
@@ -185,6 +186,7 @@ class IngressServiceClient(
     }
 
     private fun authHeader(vararg videoGrants: VideoGrant): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(*videoGrants)
 

--- a/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
+++ b/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
@@ -25,6 +25,21 @@ import retrofit2.converter.protobuf.ProtoConverterFactory
 import java.util.function.Supplier
 
 /**
+ * Normalizes a host into a base URL for the HTTP server APIs. LiveKit URLs are
+ * commonly `wss://` (or `ws://`); the server APIs are Twirp over HTTP, so the
+ * scheme is converted to `https://` (or `http://`). A trailing slash is added
+ * because Retrofit requires the base URL to end in `/`.
+ */
+internal fun normalizeApiUrl(host: String): String {
+    val http = when {
+        host.startsWith("wss://") -> "https://" + host.removePrefix("wss://")
+        host.startsWith("ws://") -> "http://" + host.removePrefix("ws://")
+        else -> host
+    }
+    return if (http.endsWith("/")) http else "$http/"
+}
+
+/**
  * A single entry point to every LiveKit server API, exposing each service.
  * The services share one underlying OkHttp client and Retrofit instance.
  *
@@ -101,9 +116,8 @@ class LiveKitAPI internal constructor(
             val okhttp = okHttpSupplier.get().newBuilder()
                 .addInterceptor(RegionFailoverInterceptor(FailoverConfig(enabled = failover)))
                 .build()
-            val baseUrl = if (host.endsWith("/")) host else "$host/"
             val retrofit = Retrofit.Builder()
-                .baseUrl(baseUrl)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
+++ b/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server
+
+import io.livekit.server.okhttp.FailoverConfig
+import io.livekit.server.okhttp.OkHttpFactory
+import io.livekit.server.okhttp.RegionFailoverInterceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.protobuf.ProtoConverterFactory
+import java.util.function.Supplier
+
+/**
+ * A single entry point to every LiveKit server API, exposing each service.
+ * The services share one underlying OkHttp client and Retrofit instance.
+ *
+ * Create it with [createClient] (API key & secret) or [createClientWithToken]
+ * (a pre-signed token, for client-side use).
+ *
+ * ```
+ * val api = LiveKitAPI.createClient(host, apiKey, secret)
+ * api.room.createRoom(name = "my-room").execute()
+ * ```
+ */
+class LiveKitAPI internal constructor(
+    val room: RoomServiceClient,
+    val egress: EgressServiceClient,
+    val ingress: IngressServiceClient,
+    val sip: SipServiceClient,
+    val agentDispatch: AgentDispatchServiceClient,
+    val connector: ConnectorServiceClient,
+) {
+    companion object {
+        /**
+         * Creates a LiveKitAPI authenticated with an API key and secret. Any
+         * omitted value falls back to `LIVEKIT_URL` / `LIVEKIT_API_KEY` /
+         * `LIVEKIT_API_SECRET`.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun createClient(
+            host: String? = null,
+            apiKey: String? = null,
+            secret: String? = null,
+            okHttpSupplier: Supplier<OkHttpClient> = OkHttpFactory(),
+            failover: Boolean = true,
+        ): LiveKitAPI {
+            val h = host ?: System.getenv("LIVEKIT_URL")
+            val k = apiKey ?: System.getenv("LIVEKIT_API_KEY")
+            val s = secret ?: System.getenv("LIVEKIT_API_SECRET")
+            require(!h.isNullOrEmpty()) { "host is required (pass it or set LIVEKIT_URL)" }
+            require(!k.isNullOrEmpty() && !s.isNullOrEmpty()) {
+                "apiKey and secret are required (pass them or set LIVEKIT_API_KEY / LIVEKIT_API_SECRET)"
+            }
+            return build(h, k, s, null, okHttpSupplier, failover)
+        }
+
+        /**
+         * Creates a LiveKitAPI authenticated with a pre-signed token, sent verbatim
+         * (no secret required, so it can run client-side). The token must already
+         * carry the grants for the calls it's used with. `host` falls back to
+         * `LIVEKIT_URL` and `token` to `LIVEKIT_TOKEN`.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun createClientWithToken(
+            host: String? = null,
+            token: String? = null,
+            okHttpSupplier: Supplier<OkHttpClient> = OkHttpFactory(),
+            failover: Boolean = true,
+        ): LiveKitAPI {
+            val h = host ?: System.getenv("LIVEKIT_URL")
+            val t = token ?: System.getenv("LIVEKIT_TOKEN")
+            require(!h.isNullOrEmpty()) { "host is required (pass it or set LIVEKIT_URL)" }
+            require(!t.isNullOrEmpty()) { "token is required (pass it or set LIVEKIT_TOKEN)" }
+            return build(h, "", "", t, okHttpSupplier, failover)
+        }
+
+        private fun build(
+            host: String,
+            apiKey: String,
+            secret: String,
+            token: String?,
+            okHttpSupplier: Supplier<OkHttpClient>,
+            failover: Boolean,
+        ): LiveKitAPI {
+            val okhttp = okHttpSupplier.get().newBuilder()
+                .addInterceptor(RegionFailoverInterceptor(FailoverConfig(enabled = failover)))
+                .build()
+            val baseUrl = if (host.endsWith("/")) host else "$host/"
+            val retrofit = Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .addConverterFactory(ProtoConverterFactory.create())
+                .client(okhttp)
+                .build()
+            return LiveKitAPI(
+                room = RoomServiceClient(retrofit.create(RoomService::class.java), apiKey, secret, token),
+                egress = EgressServiceClient(retrofit.create(EgressService::class.java), apiKey, secret, token),
+                ingress = IngressServiceClient(retrofit.create(IngressService::class.java), apiKey, secret, token),
+                sip = SipServiceClient(retrofit.create(SipService::class.java), apiKey, secret, token),
+                agentDispatch = AgentDispatchServiceClient(
+                    retrofit.create(AgentDispatchService::class.java), apiKey, secret, token,
+                ),
+                connector = ConnectorServiceClient(retrofit.create(ConnectorService::class.java), apiKey, secret, token),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
+++ b/src/main/kotlin/io/livekit/server/LiveKitAPI.kt
@@ -127,7 +127,10 @@ class LiveKitAPI internal constructor(
                 ingress = IngressServiceClient(retrofit.create(IngressService::class.java), apiKey, secret, token),
                 sip = SipServiceClient(retrofit.create(SipService::class.java), apiKey, secret, token),
                 agentDispatch = AgentDispatchServiceClient(
-                    retrofit.create(AgentDispatchService::class.java), apiKey, secret, token,
+                    retrofit.create(AgentDispatchService::class.java),
+                    apiKey,
+                    secret,
+                    token,
                 ),
                 connector = ConnectorServiceClient(retrofit.create(ConnectorService::class.java), apiKey, secret, token),
             )

--- a/src/main/kotlin/io/livekit/server/RoomServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/RoomServiceClient.kt
@@ -180,16 +180,22 @@ class RoomServiceClient(
      * @param roomName
      * @param identity
      */
-    fun removeParticipant(roomName: String, identity: String): Call<Void?> {
-        val request = LivekitRoom.RoomParticipantIdentity.newBuilder()
+    @JvmOverloads
+    fun removeParticipant(
+        roomName: String,
+        identity: String,
+        // Revoke all tokens issued to this participant before this Unix timestamp (ms).
+        revokeTokenTs: Long? = null,
+    ): Call<Void?> {
+        val builder = LivekitRoom.RoomParticipantIdentity.newBuilder()
             .setRoom(roomName)
             .setIdentity(identity)
-            .build()
+        revokeTokenTs?.let { builder.setRevokeTokenTs(it) }
         val credentials = authHeader(
             RoomAdmin(true),
             RoomName(roomName),
         )
-        return service.removeParticipant(request, credentials)
+        return service.removeParticipant(builder.build(), credentials)
     }
 
     /**
@@ -445,7 +451,7 @@ class RoomServiceClient(
                 .addInterceptor(RegionFailoverInterceptor(FailoverConfig(enabled = failover)))
                 .build()
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()

--- a/src/main/kotlin/io/livekit/server/RoomServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/RoomServiceClient.kt
@@ -42,6 +42,7 @@ class RoomServiceClient(
     private val service: RoomService,
     private val apiKey: String,
     private val secret: String,
+    private val token: String? = null,
 ) {
 
     /**
@@ -377,6 +378,7 @@ class RoomServiceClient(
     }
 
     private fun authHeader(vararg videoGrants: VideoGrant): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(*videoGrants)
 

--- a/src/main/kotlin/io/livekit/server/ServerError.kt
+++ b/src/main/kotlin/io/livekit/server/ServerError.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server
+
+import com.google.protobuf.Struct
+import com.google.protobuf.util.JsonFormat
+import retrofit2.Response
+
+/**
+ * A LiveKit server API error, parsed from a failed [Response]. Retrofit itself
+ * doesn't raise on API errors, so callers inspect the response and use [from] to
+ * decode the error body.
+ */
+open class ServerError internal constructor(
+    /** The error code, e.g. "not_found" or "permission_denied". */
+    val code: String,
+    /** The server-provided error message. */
+    val message: String,
+    /** Additional error metadata returned by the server. */
+    val metadata: Map<String, String>,
+) {
+    override fun toString(): String {
+        val meta = if (metadata.isEmpty()) "" else ", metadata=$metadata"
+        return "ServerError(code=$code, message=$message$meta)"
+    }
+
+    companion object {
+        /**
+         * Decodes a [ServerError] (or [SipCallError]) from a failed [response], or
+         * null when the response succeeded or its body isn't a server error.
+         */
+        @JvmStatic
+        fun from(response: Response<*>): ServerError? {
+            if (response.isSuccessful) return null
+            val body = response.errorBody()?.string() ?: return null
+            return parse(body)
+        }
+
+        internal fun parse(body: String): ServerError? = try {
+            val builder = Struct.newBuilder()
+            JsonFormat.parser().ignoringUnknownFields().merge(body, builder)
+            val struct = builder.build()
+            val code = struct.fieldsMap["code"]?.stringValue
+            if (code == null) {
+                null
+            } else {
+                val msg = struct.fieldsMap["msg"]?.stringValue ?: ""
+                val meta = struct.fieldsMap["meta"]?.structValue?.fieldsMap
+                    ?.mapValues { it.value.stringValue } ?: emptyMap()
+                if (meta.containsKey("sip_status_code")) {
+                    SipCallError(code, msg, meta)
+                } else {
+                    ServerError(code, msg, meta)
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+
+/**
+ * A [ServerError] from a SIP dialing call (createSipParticipant / transferSipParticipant)
+ * that failed with a SIP response status. The SIP code and reason are exposed
+ * directly; other metadata remains available via [metadata].
+ */
+class SipCallError internal constructor(
+    code: String,
+    message: String,
+    metadata: Map<String, String>,
+) : ServerError(code, message, metadata) {
+    /** The SIP response code of the failed call, e.g. 486 (Busy Here). */
+    val sipStatusCode: Int? get() = metadata["sip_status_code"]?.toIntOrNull()
+
+    /** The SIP reason phrase of the failed call, e.g. "Busy Here". */
+    val sipStatus: String? get() = metadata["sip_status"]
+
+    override fun toString(): String {
+        val reason = sipStatus?.let { " $it" } ?: ""
+        val extra = metadata.filterKeys { it !in EXCLUDED_META }
+        val extraStr = if (extra.isEmpty()) {
+            ""
+        } else {
+            " [" + extra.entries.joinToString(", ") { "${it.key}=${it.value}" } + "]"
+        }
+        return "SIP call failed: $sipStatusCode$reason ($code)$extraStr"
+    }
+
+    companion object {
+        private val EXCLUDED_META = setOf("sip_status_code", "sip_status", "error_details")
+
+        /**
+         * Decodes a [SipCallError] from a failed [response], or null when it isn't
+         * a SIP-status failure.
+         */
+        @JvmStatic
+        fun from(response: Response<*>): SipCallError? = ServerError.from(response) as? SipCallError
+    }
+}

--- a/src/main/kotlin/io/livekit/server/ServiceClientBase.kt
+++ b/src/main/kotlin/io/livekit/server/ServiceClientBase.kt
@@ -29,9 +29,13 @@ open class ServiceClientBase(
     private val apiKey: String,
     private val secret: String,
     private val ttl: Long = TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES),
+    // A pre-signed token, set by LiveKitAPI for token auth; sent verbatim,
+    // skipping per-call signing.
+    private val token: String? = null,
 ) {
 
     protected fun authHeader(vararg videoGrants: VideoGrant): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(*videoGrants)
         accessToken.ttl = ttl
@@ -42,6 +46,7 @@ open class ServiceClientBase(
     }
 
     protected fun authHeader(videoGrants: List<VideoGrant> = emptyList(), sipGrants: List<SIPGrant> = emptyList()): String {
+        token?.let { return "Bearer $it" }
         val accessToken = AccessToken(apiKey, secret)
         accessToken.addGrants(videoGrants)
         accessToken.addSIPGrants(sipGrants)

--- a/src/main/kotlin/io/livekit/server/SipServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/SipServiceClient.kt
@@ -25,6 +25,7 @@ import livekit.LivekitModels.ListUpdate
 import livekit.LivekitRoom
 import livekit.LivekitSip
 import livekit.LivekitSip.SIPDispatchRule
+import livekit.LivekitSip.SIPDispatchRuleCallee
 import livekit.LivekitSip.SIPDispatchRuleDirect
 import livekit.LivekitSip.SIPDispatchRuleIndividual
 import livekit.LivekitSip.SIPDispatchRuleInfo
@@ -71,6 +72,13 @@ class SipServiceClient(
                     opt.allowedNumbers?.let { this.addAllAllowedNumbers(it) }
                     opt.authUsername?.let { this.authUsername = it }
                     opt.authPassword?.let { this.authPassword = it }
+                    opt.authRealm?.let { this.authRealm = it }
+                    opt.krispEnabled?.let { this.krispEnabled = it }
+                    opt.ringingTimeout?.let { this.ringingTimeout = secondsDuration(it) }
+                    opt.maxCallDuration?.let { this.maxCallDuration = secondsDuration(it) }
+                    opt.headers?.let { this.putAllHeaders(it) }
+                    opt.headersToAttributes?.let { this.putAllHeadersToAttributes(it) }
+                    opt.attributesToHeaders?.let { this.putAllAttributesToHeaders(it) }
                 }
                 build()
             }
@@ -107,6 +115,9 @@ class SipServiceClient(
                     opt.authUsername?.let { this.authUsername = it }
                     opt.authPassword?.let { this.authPassword = it }
                     opt.destinationCountry?.let { this.destinationCountry = it }
+                    opt.headers?.let { this.putAllHeaders(it) }
+                    opt.headersToAttributes?.let { this.putAllHeadersToAttributes(it) }
+                    opt.attributesToHeaders?.let { this.putAllAttributesToHeaders(it) }
                 }
                 build()
             }
@@ -149,6 +160,26 @@ class SipServiceClient(
     }
 
     /**
+     * UpdateSIPInboundTrunk replaces an existing SIP Inbound Trunk in its entirety with the
+     * provided [trunk] info. Unlike the field-level [updateSipInboundTrunk] overload, every field
+     * is overwritten with the given value.
+     */
+    @Suppress("unused")
+    fun updateSipInboundTrunk(
+        sipTrunkId: String,
+        trunk: LivekitSip.SIPInboundTrunkInfo,
+    ): Call<LivekitSip.SIPInboundTrunkInfo> {
+        val request = with(LivekitSip.UpdateSIPInboundTrunkRequest.newBuilder()) {
+            this.sipTrunkId = sipTrunkId
+            this.replace = trunk
+            build()
+        }
+
+        val credentials = authHeader(emptyList(), listOf(SIPAdmin()))
+        return service.updateSipInboundTrunk(request, credentials)
+    }
+
+    /**
      * UpdateSIPOutboundTrunk updates an existing SIP Outbound Trunk.
      */
     @JvmOverloads
@@ -173,6 +204,26 @@ class SipServiceClient(
                 }
                 build()
             }
+            build()
+        }
+
+        val credentials = authHeader(emptyList(), listOf(SIPAdmin()))
+        return service.updateSipOutboundTrunk(request, credentials)
+    }
+
+    /**
+     * UpdateSIPOutboundTrunk replaces an existing SIP Outbound Trunk in its entirety with the
+     * provided [trunk] info. Unlike the field-level [updateSipOutboundTrunk] overload, every field
+     * is overwritten with the given value.
+     */
+    @Suppress("unused")
+    fun updateSipOutboundTrunk(
+        sipTrunkId: String,
+        trunk: LivekitSip.SIPOutboundTrunkInfo,
+    ): Call<LivekitSip.SIPOutboundTrunkInfo> {
+        val request = with(LivekitSip.UpdateSIPOutboundTrunkRequest.newBuilder()) {
+            this.sipTrunkId = sipTrunkId
+            this.replace = trunk
             build()
         }
 
@@ -265,6 +316,15 @@ class SipServiceClient(
                                 build()
                             }
                         }
+
+                        is SipDispatchRuleCallee -> {
+                            dispatchRuleCallee = with(SIPDispatchRuleCallee.newBuilder()) {
+                                roomPrefix = rule.roomPrefix
+                                rule.pin?.let { this.pin = it }
+                                rule.randomize?.let { this.randomize = it }
+                                build()
+                            }
+                        }
                     }
                     build()
                 }
@@ -307,6 +367,15 @@ class SipServiceClient(
                                     dispatchRuleIndividual = with(SIPDispatchRuleIndividual.newBuilder()) {
                                         roomPrefix = optRule.roomPrefix
                                         optRule.pin?.let { this.pin = it }
+                                        build()
+                                    }
+                                }
+
+                                is SipDispatchRuleCallee -> {
+                                    dispatchRuleCallee = with(SIPDispatchRuleCallee.newBuilder()) {
+                                        roomPrefix = optRule.roomPrefix
+                                        optRule.pin?.let { this.pin = it }
+                                        optRule.randomize?.let { this.randomize = it }
                                         build()
                                     }
                                 }
@@ -480,7 +549,7 @@ class SipServiceClient(
                 .build()
 
             val service = Retrofit.Builder()
-                .baseUrl(host)
+                .baseUrl(normalizeApiUrl(host))
                 .addConverterFactory(ProtoConverterFactory.create())
                 .client(okhttp)
                 .build()
@@ -497,6 +566,15 @@ data class CreateSipInboundTrunkOptions(
     var allowedNumbers: List<String>? = null,
     var authUsername: String? = null,
     var authPassword: String? = null,
+    var authRealm: String? = null,
+    var krispEnabled: Boolean? = null,
+    /** Max time to ring, in seconds. */
+    var ringingTimeout: Int? = null,
+    /** Max call duration, in seconds. */
+    var maxCallDuration: Int? = null,
+    var headers: Map<String, String>? = null,
+    var headersToAttributes: Map<String, String>? = null,
+    var attributesToHeaders: Map<String, String>? = null,
 )
 
 data class CreateSipOutboundTrunkOptions(
@@ -505,6 +583,9 @@ data class CreateSipOutboundTrunkOptions(
     var authUsername: String? = null,
     var authPassword: String? = null,
     var destinationCountry: String? = null,
+    var headers: Map<String, String>? = null,
+    var headersToAttributes: Map<String, String>? = null,
+    var attributesToHeaders: Map<String, String>? = null,
 )
 
 data class UpdateSipInboundTrunkOptions(
@@ -531,6 +612,7 @@ data class UpdateSipOutboundTrunkOptions(
 /**
  * @see SipDispatchRuleDirect
  * @see SipDispatchRuleIndividual
+ * @see SipDispatchRuleCallee
  */
 sealed class SipDispatchRule(var type: String)
 
@@ -551,6 +633,17 @@ data class SipDispatchRuleIndividual(
     var roomPrefix: String,
     var pin: String? = null,
 ) : SipDispatchRule("individual")
+
+/**
+ * This creates a Dispatch Rule that creates a new room for each callee.
+ * The created room name will use the given roomPrefix, optionally followed by a random suffix
+ * when randomize is set.
+ */
+data class SipDispatchRuleCallee(
+    var roomPrefix: String,
+    var pin: String? = null,
+    var randomize: Boolean? = null,
+) : SipDispatchRule("callee")
 
 data class CreateSipDispatchRuleOptions(
     /** Human-readable name for the Dispatch Rule. */

--- a/src/main/kotlin/io/livekit/server/SipServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/SipServiceClient.kt
@@ -45,7 +45,8 @@ class SipServiceClient(
     private val service: SipService,
     apiKey: String,
     secret: String,
-) : ServiceClientBase(apiKey, secret) {
+    token: String? = null,
+) : ServiceClientBase(apiKey, secret, token = token) {
 
     /**
      * Creates an inbound trunk to accept incoming calls.
@@ -377,6 +378,9 @@ class SipServiceClient(
             ringingTimeout?.let { this.ringingTimeout = secondsDuration(it) }
 
             options?.let { opts ->
+                opts.outboundConfig?.let { this.trunk = it }
+                opts.fromNumber?.let { this.sipNumber = it }
+                opts.displayName?.let { this.displayName = it }
                 opts.participantIdentity?.let { this.participantIdentity = it }
                 opts.participantName?.let { this.participantName = it }
                 opts.participantMetadata?.let { this.participantMetadata = it }
@@ -584,6 +588,12 @@ data class CreateSipParticipantOptions(
     var participantIdentity: String?,
     var participantName: String? = null,
     var participantMetadata: String? = null,
+    /** Inline outbound trunk configuration, used instead of a stored trunk ID. */
+    var outboundConfig: LivekitSip.SIPOutboundConfig? = null,
+    /** SIP From number. Required when using an inline [outboundConfig]. */
+    var fromNumber: String? = null,
+    /** Custom caller ID shown to the callee. Requires provider support. */
+    var displayName: String? = null,
     var dtmf: String? = null,
     /** deprecated, use playDialtone instead */
     var playRingtone: Boolean? = null,

--- a/src/main/kotlin/io/livekit/server/okhttp/OkHttpSupplier.kt
+++ b/src/main/kotlin/io/livekit/server/okhttp/OkHttpSupplier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 LiveKit, Inc.
+ * Copyright 2025-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/io/livekit/server/okhttp/OkHttpSupplier.kt
+++ b/src/main/kotlin/io/livekit/server/okhttp/OkHttpSupplier.kt
@@ -47,6 +47,7 @@ constructor(
 
     val okHttp by lazy {
         with(OkHttpClient.Builder()) {
+            addInterceptor(UserAgentInterceptor())
             if (logging) {
                 val loggingInterceptor = HttpLoggingInterceptor()
                 loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)

--- a/src/main/kotlin/io/livekit/server/okhttp/UserAgentInterceptor.kt
+++ b/src/main/kotlin/io/livekit/server/okhttp/UserAgentInterceptor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server.okhttp
+
+import io.livekit.server.SDK_VERSION
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/** Identifies the SDK and version to the server on every request. */
+internal class UserAgentInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("User-Agent", "livekit-server-sdk-kotlin/$SDK_VERSION")
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/src/test/kotlin/io/livekit/server/UrlNormalizationTest.kt
+++ b/src/test/kotlin/io/livekit/server/UrlNormalizationTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UrlNormalizationTest {
+    @Test
+    fun convertsWebSocketSchemesToHttp() {
+        assertEquals("https://my.livekit.cloud/", normalizeApiUrl("wss://my.livekit.cloud"))
+        assertEquals("http://localhost:7880/", normalizeApiUrl("ws://localhost:7880"))
+    }
+
+    @Test
+    fun leavesHttpSchemesUntouched() {
+        assertEquals("https://my.livekit.cloud/", normalizeApiUrl("https://my.livekit.cloud"))
+        assertEquals("http://localhost:7880/", normalizeApiUrl("http://localhost:7880"))
+    }
+
+    @Test
+    fun preservesExistingTrailingSlash() {
+        assertEquals("https://my.livekit.cloud/", normalizeApiUrl("wss://my.livekit.cloud/"))
+    }
+}

--- a/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
+++ b/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
@@ -22,11 +22,11 @@ import io.livekit.server.CreateSipParticipantOptions
 import io.livekit.server.EncodedOutputs
 import io.livekit.server.LiveKitAPI
 import io.livekit.server.RoomCreate
+import io.livekit.server.ServerError
 import io.livekit.server.SipCallError
 import io.livekit.server.SipDispatchRuleCallee
 import io.livekit.server.SipDispatchRuleDirect
 import io.livekit.server.TransferSipParticipantOptions
-import io.livekit.server.ServerError
 import io.livekit.server.UpdateSipDispatchRuleOptions
 import io.livekit.server.UpdateSipInboundTrunkOptions
 import io.livekit.server.UpdateSipOutboundTrunkOptions
@@ -95,7 +95,10 @@ class LiveKitApiTest {
         assertOk(api.room.mutePublishedTrack("test-room", "participant-42", "TR_video1", true))
         assertOk(
             api.room.updateParticipant(
-                "test-room", "participant-42", name = "Alice", metadata = "{}",
+                "test-room",
+                "participant-42",
+                name = "Alice",
+                metadata = "{}",
                 attributes = mapOf("seat" to "1A"),
             ),
         )
@@ -103,8 +106,11 @@ class LiveKitApiTest {
         assertOk(api.room.updateRoomMetadata("test-room", "{}"))
         assertOk(
             api.room.sendData(
-                "test-room", "hello".toByteArray(), LivekitModels.DataPacket.Kind.RELIABLE,
-                destinationIdentities = listOf("participant-42"), topic = "chat",
+                "test-room",
+                "hello".toByteArray(),
+                LivekitModels.DataPacket.Kind.RELIABLE,
+                destinationIdentities = listOf("participant-42"),
+                topic = "chat",
             ),
         )
     }
@@ -134,8 +140,11 @@ class LiveKitApiTest {
         val api = api()
         assertOk(
             api.ingress.createIngress(
-                name = "stream-input", roomName = "test-room", participantIdentity = "ingress-bot",
-                participantName = "Live Stream", inputType = livekit.LivekitIngress.IngressInput.RTMP_INPUT,
+                name = "stream-input",
+                roomName = "test-room",
+                participantIdentity = "ingress-bot",
+                participantName = "Live Stream",
+                inputType = livekit.LivekitIngress.IngressInput.RTMP_INPUT,
                 enableTranscoding = true,
             ),
         )
@@ -151,10 +160,14 @@ class LiveKitApiTest {
         assertOk(api.sip.createSipInboundTrunk("inbound", listOf("+15105550100")))
         assertOk(
             api.sip.createSipInboundTrunk(
-                "inbound-krisp", listOf("+15105550101"),
+                "inbound-krisp",
+                listOf("+15105550101"),
                 CreateSipInboundTrunkOptions(
-                    krispEnabled = true, ringingTimeout = 30, maxCallDuration = 3600,
-                    headers = mapOf("X-Custom" to "1"), headersToAttributes = mapOf("X-Custom" to "custom"),
+                    krispEnabled = true,
+                    ringingTimeout = 30,
+                    maxCallDuration = 3600,
+                    headers = mapOf("X-Custom" to "1"),
+                    headersToAttributes = mapOf("X-Custom" to "custom"),
                 ),
             ),
         )
@@ -195,7 +208,8 @@ class LiveKitApiTest {
         assertOk(api.connector.acceptWhatsAppCall("123456789012345", "wa-secret-key", "23.0", "wacid.HBgLABC", offer))
         assertOk(
             api.connector.disconnectWhatsAppCall(
-                "wacid.HBgLABC", "wa-secret-key",
+                "wacid.HBgLABC",
+                "wa-secret-key",
                 LivekitConnectorWhatsapp.DisconnectWhatsAppCallRequest.DisconnectReason.BUSINESS_INITIATED,
             ),
         )
@@ -237,7 +251,9 @@ class LiveKitApiTest {
     fun sipParticipant() {
         if (!MockControl.serverUp()) return
         val p = api().sip.createSipParticipant(
-            "ST_abc123", "+15105550100", "test-room",
+            "ST_abc123",
+            "+15105550100",
+            "test-room",
             CreateSipParticipantOptions(participantIdentity = "sip-caller", participantName = "SIP Caller"),
         ).execute().body()
         assertNotNull(p)
@@ -246,7 +262,9 @@ class LiveKitApiTest {
 
         // Inline outbound trunk config (no stored trunk id) + custom caller ID.
         val inline = api().sip.createSipParticipant(
-            "", "+15105550100", "test-room",
+            "",
+            "+15105550100",
+            "test-room",
             CreateSipParticipantOptions(
                 participantIdentity = "sip-inline",
                 outboundConfig = LivekitSip.SIPOutboundConfig.newBuilder()
@@ -261,13 +279,17 @@ class LiveKitApiTest {
         val waitApi = api(MockControl.json("delayMs" to 0))
         assertOk(
             waitApi.sip.createSipParticipant(
-                "ST_abc123", "+15105550100", "test-room",
+                "ST_abc123",
+                "+15105550100",
+                "test-room",
                 CreateSipParticipantOptions(participantIdentity = "sip-caller", waitUntilAnswered = true, ringingTimeout = 2),
             ),
         )
         assertOk(
             waitApi.sip.transferSipParticipant(
-                "test-room", "sip-caller", "tel:+15105550122",
+                "test-room",
+                "sip-caller",
+                "tel:+15105550122",
                 TransferSipParticipantOptions(ringingTimeout = 2),
             ),
         )
@@ -328,7 +350,9 @@ class LiveKitApiTest {
         if (!MockControl.serverUp()) return
         // ringingTimeout 1s -> ~3s dial budget; the mock delays the answer past it.
         val call = api(MockControl.json("delayMs" to 4000)).sip.createSipParticipant(
-            "ST_abc123", "+15105550100", "test-room",
+            "ST_abc123",
+            "+15105550100",
+            "test-room",
             CreateSipParticipantOptions(participantIdentity = "sip-caller", waitUntilAnswered = true, ringingTimeout = 1),
         )
         assertFailsWith<java.io.IOException> { call.execute() }

--- a/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
+++ b/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server.api
+
+import io.livekit.server.AccessToken
+import io.livekit.server.CreateSipParticipantOptions
+import io.livekit.server.LiveKitAPI
+import io.livekit.server.RoomCreate
+import io.livekit.server.SipCallError
+import io.livekit.server.SipDispatchRuleDirect
+import io.livekit.server.TransferSipParticipantOptions
+import io.livekit.server.ServerError
+import io.livekit.server.okhttp.OkHttpFactory
+import io.livekit.server.okhttp.OkHttpHolder
+import livekit.LivekitConnectorTwilio
+import livekit.LivekitConnectorWhatsapp
+import livekit.LivekitEgress
+import livekit.LivekitModels
+import livekit.LivekitRtc
+import okhttp3.OkHttpClient
+import retrofit2.Call
+import java.util.function.Supplier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * API tests that drive the unified [LiveKitAPI] against the mock LiveKit server.
+ * See [MockControl] for setup; tests no-op when it is not reachable. Because the
+ * mock enforces the same per-method grants as the real server, a call that
+ * succeeds also proves the SDK attached the right grants. Mock directives are
+ * injected as a default X-Lk-Mock header on the shared OkHttp client (the
+ * Retrofit methods don't expose per-call headers).
+ */
+class LiveKitApiTest {
+    private fun api(mock: String? = null): LiveKitAPI {
+        val supplier: Supplier<OkHttpClient> = if (mock == null) {
+            OkHttpFactory()
+        } else {
+            OkHttpHolder(
+                OkHttpClient.Builder()
+                    .addInterceptor { chain ->
+                        chain.proceed(chain.request().newBuilder().header("X-Lk-Mock", mock).build())
+                    }
+                    .build(),
+            )
+        }
+        return LiveKitAPI.createClient(MockControl.base, "devkey", "secret", supplier)
+    }
+
+    private fun assertOk(call: Call<*>) {
+        val resp = call.execute()
+        assertTrue(resp.isSuccessful, "expected success, got ${resp.code()}: ${resp.errorBody()?.string()}")
+    }
+
+    // -- smoke: fully-populated calls across every service ----------------------
+
+    @Test
+    fun roomSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        assertOk(api.room.createRoom(name = "test-room", emptyTimeout = 300, maxParticipants = 50, metadata = "{}"))
+        assertOk(api.room.listRooms(listOf("test-room", "lobby")))
+        assertOk(api.room.deleteRoom("test-room"))
+        assertOk(api.room.listParticipants("test-room"))
+        assertOk(api.room.getParticipant("test-room", "participant-42"))
+        assertOk(api.room.removeParticipant("test-room", "participant-42"))
+        assertOk(api.room.forwardParticipant("test-room", "participant-42", "overflow-room"))
+        assertOk(api.room.moveParticipant("test-room", "participant-42", "breakout-room"))
+        assertOk(api.room.mutePublishedTrack("test-room", "participant-42", "TR_video1", true))
+        assertOk(
+            api.room.updateParticipant(
+                "test-room", "participant-42", name = "Alice", metadata = "{}",
+                attributes = mapOf("seat" to "1A"),
+            ),
+        )
+        assertOk(api.room.updateSubscriptions("test-room", "participant-42", listOf("TR_video1"), true))
+        assertOk(api.room.updateRoomMetadata("test-room", "{}"))
+        assertOk(
+            api.room.sendData(
+                "test-room", "hello".toByteArray(), LivekitModels.DataPacket.Kind.RELIABLE,
+                destinationIdentities = listOf("participant-42"), topic = "chat",
+            ),
+        )
+    }
+
+    @Test
+    fun egressSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        val file = LivekitEgress.EncodedFileOutput.newBuilder()
+            .setFileType(LivekitEgress.EncodedFileType.MP4).setFilepath("room.mp4").build()
+        assertOk(api.egress.startRoomCompositeEgress("test-room", file, layout = "grid"))
+        val stream = LivekitEgress.StreamOutput.newBuilder()
+            .setProtocol(LivekitEgress.StreamProtocol.RTMP).addUrls("rtmps://a.example.com/live/key").build()
+        assertOk(api.egress.startWebEgress("https://example.com/scene", stream))
+        assertOk(api.egress.updateLayout("EG_abc123", "speaker"))
+        assertOk(api.egress.updateStream("EG_abc123", addOutputUrls = listOf("rtmps://b.example.com/live/key")))
+        assertOk(api.egress.listEgress(roomName = "test-room", egressId = "EG_abc123", active = true))
+        assertOk(api.egress.stopEgress("EG_abc123"))
+    }
+
+    @Test
+    fun ingressSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        assertOk(
+            api.ingress.createIngress(
+                name = "stream-input", roomName = "test-room", participantIdentity = "ingress-bot",
+                participantName = "Live Stream", inputType = livekit.LivekitIngress.IngressInput.RTMP_INPUT,
+                enableTranscoding = true,
+            ),
+        )
+        assertOk(api.ingress.updateIngress("IN_abc123", name = "stream-input-v2", roomName = "test-room"))
+        assertOk(api.ingress.listIngress(roomName = "test-room", ingressId = "IN_abc123"))
+        assertOk(api.ingress.deleteIngress("IN_abc123"))
+    }
+
+    @Test
+    fun sipSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        assertOk(api.sip.createSipInboundTrunk("inbound", listOf("+15105550100")))
+        assertOk(api.sip.createSipOutboundTrunk("outbound", "sip.telco.example.com", listOf("+15105550100")))
+        assertOk(api.sip.listSipInboundTrunk())
+        assertOk(api.sip.listSipOutboundTrunk())
+        assertOk(api.sip.deleteSipTrunk("ST_abc123"))
+        assertOk(api.sip.createSipDispatchRule(SipDispatchRuleDirect(roomName = "support", pin = "1234")))
+        assertOk(api.sip.listSipDispatchRule())
+        assertOk(api.sip.deleteSipDispatchRule("SDR_abc123"))
+    }
+
+    @Test
+    fun connectorSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        val offer = LivekitRtc.SessionDescription.newBuilder().setType("offer").setSdp("v=0\r\n").build()
+        assertOk(api.connector.dialWhatsAppCall("123456789012345", "+15105550100", "wa-secret-key", "23.0"))
+        assertOk(api.connector.connectWhatsAppCall("wacid.HBgLABC", offer))
+        assertOk(
+            api.connector.disconnectWhatsAppCall(
+                "wacid.HBgLABC", "wa-secret-key",
+                LivekitConnectorWhatsapp.DisconnectWhatsAppCallRequest.DisconnectReason.BUSINESS_INITIATED,
+            ),
+        )
+        assertOk(
+            api.connector.connectTwilioCall(
+                LivekitConnectorTwilio.ConnectTwilioCallRequest.TwilioCallDirection.TWILIO_CALL_DIRECTION_INBOUND,
+            ),
+        )
+    }
+
+    @Test
+    fun agentDispatchSmoke() {
+        if (!MockControl.serverUp()) return
+        val api = api()
+        assertOk(api.agentDispatch.createDispatch("test-room", "inbound-agent", metadata = "{}"))
+        assertOk(api.agentDispatch.listDispatch("test-room"))
+        assertOk(api.agentDispatch.getDispatch("test-room", "AD_abc123"))
+        assertOk(api.agentDispatch.deleteDispatch("test-room", "AD_abc123"))
+    }
+
+    // -- deep: create_room round-trip -------------------------------------------
+
+    @Test
+    fun createRoomEchoesFields() {
+        if (!MockControl.serverUp()) return
+        val room = api().room.createRoom(name = "echo-room", metadata = "{\"scene\":\"lobby\"}", emptyTimeout = 300, maxParticipants = 50)
+            .execute().body()
+        assertNotNull(room)
+        assertEquals("echo-room", room.name)
+        assertEquals("{\"scene\":\"lobby\"}", room.metadata)
+        assertEquals(300, room.emptyTimeout)
+        assertEquals(50, room.maxParticipants)
+        assertTrue(room.sid.isNotEmpty()) // placeholder assigned by the mock
+    }
+
+    // -- deep: SIP participant (delayMs:0 skips the mock's answer wait) ----------
+
+    @Test
+    fun sipParticipant() {
+        if (!MockControl.serverUp()) return
+        val p = api().sip.createSipParticipant(
+            "ST_abc123", "+15105550100", "test-room",
+            CreateSipParticipantOptions(participantIdentity = "sip-caller", participantName = "SIP Caller"),
+        ).execute().body()
+        assertNotNull(p)
+        assertEquals("test-room", p.roomName)
+        assertEquals("sip-caller", p.participantIdentity)
+
+        val waitApi = api(MockControl.json("delayMs" to 0))
+        assertOk(
+            waitApi.sip.createSipParticipant(
+                "ST_abc123", "+15105550100", "test-room",
+                CreateSipParticipantOptions(participantIdentity = "sip-caller", waitUntilAnswered = true, ringingTimeout = 2),
+            ),
+        )
+        assertOk(
+            waitApi.sip.transferSipParticipant(
+                "test-room", "sip-caller", "tel:+15105550122",
+                TransferSipParticipantOptions(ringingTimeout = 2),
+            ),
+        )
+    }
+
+    // -- cross-cutting: token auth ----------------------------------------------
+
+    @Test
+    fun tokenAuth() {
+        if (!MockControl.serverUp()) return
+        val token = AccessToken("devkey", "secret").apply { addGrants(RoomCreate(true)) }.toJwt()
+        val api = LiveKitAPI.createClientWithToken(MockControl.base, token)
+        val room = api.room.createRoom(name = "token-room").execute().body()
+        assertNotNull(room)
+        assertEquals("token-room", room.name)
+    }
+
+    // -- cross-cutting: SIP call errors parse into SipCallError ------------------
+
+    private fun sipError(sipStatus: Map<String, Any>): SipCallError {
+        val api = api(MockControl.json("delayMs" to 0, "sipStatus" to sipStatus))
+        val resp = api.sip.createSipParticipant("ST_abc123", "+15105550100", "test-room").execute()
+        assertFalse(resp.isSuccessful)
+        return assertNotNull(SipCallError.from(resp))
+    }
+
+    @Test
+    fun sipBusy() {
+        if (!MockControl.serverUp()) return
+        val e = sipError(mapOf("code" to 486, "status" to "Busy Here"))
+        assertTrue(e is ServerError)
+        assertEquals("resource_exhausted", e.code)
+        assertEquals(486, e.sipStatusCode)
+        assertEquals("Busy Here", e.sipStatus)
+        assertTrue(e.toString().contains("486") && e.toString().contains("Busy Here"))
+    }
+
+    @Test
+    fun sipDeclined() {
+        if (!MockControl.serverUp()) return
+        val e = sipError(mapOf("code" to 603, "status" to "Decline"))
+        assertEquals("permission_denied", e.code)
+        assertEquals(603, e.sipStatusCode)
+    }
+
+    @Test
+    fun sipNoAnswer() {
+        if (!MockControl.serverUp()) return
+        val e = sipError(mapOf("code" to 408, "status" to "Request Timeout"))
+        assertEquals("deadline_exceeded", e.code)
+        assertEquals(408, e.sipStatusCode)
+    }
+
+    // -- cross-cutting: client-side dial timeout --------------------------------
+
+    @Test
+    fun sipDialTimeout() {
+        if (!MockControl.serverUp()) return
+        // ringingTimeout 1s -> ~3s dial budget; the mock delays the answer past it.
+        val call = api(MockControl.json("delayMs" to 4000)).sip.createSipParticipant(
+            "ST_abc123", "+15105550100", "test-room",
+            CreateSipParticipantOptions(participantIdentity = "sip-caller", waitUntilAnswered = true, ringingTimeout = 1),
+        )
+        assertFailsWith<java.io.IOException> { call.execute() }
+    }
+}

--- a/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
+++ b/src/test/kotlin/io/livekit/server/api/LiveKitApiTest.kt
@@ -17,13 +17,19 @@
 package io.livekit.server.api
 
 import io.livekit.server.AccessToken
+import io.livekit.server.CreateSipInboundTrunkOptions
 import io.livekit.server.CreateSipParticipantOptions
+import io.livekit.server.EncodedOutputs
 import io.livekit.server.LiveKitAPI
 import io.livekit.server.RoomCreate
 import io.livekit.server.SipCallError
+import io.livekit.server.SipDispatchRuleCallee
 import io.livekit.server.SipDispatchRuleDirect
 import io.livekit.server.TransferSipParticipantOptions
 import io.livekit.server.ServerError
+import io.livekit.server.UpdateSipDispatchRuleOptions
+import io.livekit.server.UpdateSipInboundTrunkOptions
+import io.livekit.server.UpdateSipOutboundTrunkOptions
 import io.livekit.server.okhttp.OkHttpFactory
 import io.livekit.server.okhttp.OkHttpHolder
 import livekit.LivekitConnectorTwilio
@@ -31,6 +37,7 @@ import livekit.LivekitConnectorWhatsapp
 import livekit.LivekitEgress
 import livekit.LivekitModels
 import livekit.LivekitRtc
+import livekit.LivekitSip
 import okhttp3.OkHttpClient
 import retrofit2.Call
 import java.util.function.Supplier
@@ -82,6 +89,7 @@ class LiveKitApiTest {
         assertOk(api.room.listParticipants("test-room"))
         assertOk(api.room.getParticipant("test-room", "participant-42"))
         assertOk(api.room.removeParticipant("test-room", "participant-42"))
+        assertOk(api.room.removeParticipant("test-room", "participant-99", revokeTokenTs = 1_700_000_000_000L))
         assertOk(api.room.forwardParticipant("test-room", "participant-42", "overflow-room"))
         assertOk(api.room.moveParticipant("test-room", "participant-42", "breakout-room"))
         assertOk(api.room.mutePublishedTrack("test-room", "participant-42", "TR_video1", true))
@@ -111,6 +119,9 @@ class LiveKitApiTest {
         val stream = LivekitEgress.StreamOutput.newBuilder()
             .setProtocol(LivekitEgress.StreamProtocol.RTMP).addUrls("rtmps://a.example.com/live/key").build()
         assertOk(api.egress.startWebEgress("https://example.com/scene", stream))
+        assertOk(api.egress.startParticipantEgress("test-room", "participant-42", EncodedOutputs(file, null, null, null)))
+        assertOk(api.egress.startTrackCompositeEgress("test-room", file, "TR_audio1", "TR_video1"))
+        assertOk(api.egress.startTrackEgress("test-room", "wss://example.com/ws", "TR_video1"))
         assertOk(api.egress.updateLayout("EG_abc123", "speaker"))
         assertOk(api.egress.updateStream("EG_abc123", addOutputUrls = listOf("rtmps://b.example.com/live/key")))
         assertOk(api.egress.listEgress(roomName = "test-room", egressId = "EG_abc123", active = true))
@@ -138,11 +149,38 @@ class LiveKitApiTest {
         if (!MockControl.serverUp()) return
         val api = api()
         assertOk(api.sip.createSipInboundTrunk("inbound", listOf("+15105550100")))
+        assertOk(
+            api.sip.createSipInboundTrunk(
+                "inbound-krisp", listOf("+15105550101"),
+                CreateSipInboundTrunkOptions(
+                    krispEnabled = true, ringingTimeout = 30, maxCallDuration = 3600,
+                    headers = mapOf("X-Custom" to "1"), headersToAttributes = mapOf("X-Custom" to "custom"),
+                ),
+            ),
+        )
         assertOk(api.sip.createSipOutboundTrunk("outbound", "sip.telco.example.com", listOf("+15105550100")))
         assertOk(api.sip.listSipInboundTrunk())
         assertOk(api.sip.listSipOutboundTrunk())
+        // field-level update + full replace for both trunk kinds
+        assertOk(api.sip.updateSipInboundTrunk("ST_abc123", UpdateSipInboundTrunkOptions(metadata = "{}")))
+        assertOk(
+            api.sip.updateSipInboundTrunk(
+                "ST_abc123",
+                LivekitSip.SIPInboundTrunkInfo.newBuilder().setName("inbound").build(),
+            ),
+        )
+        assertOk(api.sip.updateSipOutboundTrunk("ST_abc123", UpdateSipOutboundTrunkOptions(metadata = "{}")))
+        assertOk(
+            api.sip.updateSipOutboundTrunk(
+                "ST_abc123",
+                LivekitSip.SIPOutboundTrunkInfo.newBuilder()
+                    .setName("outbound").setAddress("sip.telco.example.com").build(),
+            ),
+        )
         assertOk(api.sip.deleteSipTrunk("ST_abc123"))
         assertOk(api.sip.createSipDispatchRule(SipDispatchRuleDirect(roomName = "support", pin = "1234")))
+        assertOk(api.sip.createSipDispatchRule(SipDispatchRuleCallee(roomPrefix = "call-", randomize = true)))
+        assertOk(api.sip.updateSipDispatchRule("SDR_abc123", UpdateSipDispatchRuleOptions(name = "rule")))
         assertOk(api.sip.listSipDispatchRule())
         assertOk(api.sip.deleteSipDispatchRule("SDR_abc123"))
     }
@@ -154,6 +192,7 @@ class LiveKitApiTest {
         val offer = LivekitRtc.SessionDescription.newBuilder().setType("offer").setSdp("v=0\r\n").build()
         assertOk(api.connector.dialWhatsAppCall("123456789012345", "+15105550100", "wa-secret-key", "23.0"))
         assertOk(api.connector.connectWhatsAppCall("wacid.HBgLABC", offer))
+        assertOk(api.connector.acceptWhatsAppCall("123456789012345", "wa-secret-key", "23.0", "wacid.HBgLABC", offer))
         assertOk(
             api.connector.disconnectWhatsAppCall(
                 "wacid.HBgLABC", "wa-secret-key",
@@ -204,6 +243,20 @@ class LiveKitApiTest {
         assertNotNull(p)
         assertEquals("test-room", p.roomName)
         assertEquals("sip-caller", p.participantIdentity)
+
+        // Inline outbound trunk config (no stored trunk id) + custom caller ID.
+        val inline = api().sip.createSipParticipant(
+            "", "+15105550100", "test-room",
+            CreateSipParticipantOptions(
+                participantIdentity = "sip-inline",
+                outboundConfig = LivekitSip.SIPOutboundConfig.newBuilder()
+                    .setHostname("sip.telco.example.com")
+                    .setTransport(LivekitSip.SIPTransport.SIP_TRANSPORT_UDP).build(),
+                fromNumber = "+15105550199",
+                displayName = "Support",
+            ),
+        ).execute().body()
+        assertNotNull(inline)
 
         val waitApi = api(MockControl.json("delayMs" to 0))
         assertOk(

--- a/src/test/kotlin/io/livekit/server/api/MockControl.kt
+++ b/src/test/kotlin/io/livekit/server/api/MockControl.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.livekit.server.api
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Shared helpers for API tests against the mock LiveKit server (livekit/livekit
+ * cmd/test-server). Point them at a running instance with LK_TEST_SERVER_URL
+ * (default http://127.0.0.1:9999); tests no-op when it is not reachable.
+ */
+internal object MockControl {
+    val base: String = System.getenv("LK_TEST_SERVER_URL") ?: "http://127.0.0.1:9999"
+
+    fun serverUp(): Boolean = try {
+        OkHttpClient().newCall(Request.Builder().url("$base/settings/regions").build())
+            .execute().use { it.isSuccessful }
+    } catch (e: Exception) {
+        false
+    }
+
+    /**
+     * Builds an X-Lk-Mock header value from simple directives. Values may be
+     * String, Int/Long, Boolean, List, or Map (see cmd/test-server/config.go).
+     */
+    fun json(vararg entries: Pair<String, Any?>): String =
+        entries.filter { it.second != null }
+            .joinToString(",", "{", "}") { (k, v) -> "\"$k\":${encode(v!!)}" }
+
+    private fun encode(v: Any): String = when (v) {
+        is String -> "\"$v\""
+        is Boolean, is Int, is Long -> v.toString()
+        is List<*> -> v.filterNotNull().joinToString(",", "[", "]") { encode(it) }
+        is Map<*, *> -> v.entries.joinToString(",", "{", "}") { "\"${it.key}\":${encode(it.value!!)}" }
+        else -> "\"$v\""
+    }
+}

--- a/src/test/kotlin/io/livekit/server/api/RegionFailoverTest.kt
+++ b/src/test/kotlin/io/livekit/server/api/RegionFailoverTest.kt
@@ -27,32 +27,21 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Region failover tests against the shared mock LiveKit API server
- * (livekit/livekit cmd/test-server). Point them at a running instance with
- * LK_TEST_SERVER_URL (default http://127.0.0.1:9999); they no-op when no server
- * is reachable. The mock returns Cache-Control: max-age=0, so the region cache
- * never stores entries and scenarios don't interfere.
- *
- * See cmd/test-server/README.md for the X-Lk-Mock-* control protocol. These
- * tests drive the interceptor directly because the Retrofit service methods do
- * not expose per-call headers.
+ * Region failover tests against the shared mock LiveKit API server. See
+ * [MockControl] for setup and the X-Lk-Mock JSON control protocol. These drive
+ * the interceptor directly because failover relies on internal test-only knobs
+ * (force/backoffBaseMs) the service clients don't expose.
  */
 class RegionFailoverTest {
-    private val base = System.getenv("LK_TEST_SERVER_URL") ?: "http://127.0.0.1:9999"
-
-    private fun serverUp(): Boolean = try {
-        OkHttpClient().newCall(Request.Builder().url("$base/settings/regions").build())
-            .execute().use { it.isSuccessful }
-    } catch (e: Exception) {
-        false
-    }
+    private val base = MockControl.base
 
     // force bypasses the cloud-host check (the mock is on 127.0.0.1) and a tiny
     // backoff keeps the tests fast — both are internal, test-only knobs.
     private fun call(
-        directives: Map<String, String>,
+        vararg directives: Pair<String, Any?>,
         failover: Boolean = true,
         force: Boolean = true,
+        requestTimeout: String? = null,
     ): Response {
         val client = OkHttpClient.Builder()
             .addInterceptor(
@@ -62,20 +51,21 @@ class RegionFailoverTest {
             )
             .build()
         val body = ByteArray(0).toRequestBody("application/protobuf".toMediaTypeOrNull())
+        // These tests exercise failover, not authz; skip the mock's permission check.
+        val mock = MockControl.json("skipAuth" to true, *directives)
         val builder = Request.Builder()
             .url("$base/twirp/livekit.RoomService/CreateRoom")
             .post(body)
             .addHeader("Authorization", "Bearer test-token")
-            // These tests exercise failover, not authz; skip the mock's permission check.
-            .addHeader("X-Lk-Mock-Skip-Auth", "true")
-        directives.forEach { (k, v) -> builder.addHeader(k, v) }
+            .addHeader("X-Lk-Mock", mock)
+        requestTimeout?.let { builder.addHeader("X-Lk-Request-Timeout", it) }
         return client.newCall(builder.build()).execute()
     }
 
     @Test
     fun healthy() {
-        if (!serverUp()) return
-        call(emptyMap()).use {
+        if (!MockControl.serverUp()) return
+        call().use {
             assertEquals(200, it.code)
             assertEquals("0", it.header("X-Lk-Mock-Region"))
         }
@@ -83,8 +73,8 @@ class RegionFailoverTest {
 
     @Test
     fun primaryUnavailable() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0)).use {
             assertEquals(200, it.code)
             assertEquals("1", it.header("X-Lk-Mock-Region"))
         }
@@ -92,8 +82,8 @@ class RegionFailoverTest {
 
     @Test
     fun twoRegionsUnavailable() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0,1")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0, 1)).use {
             assertEquals(200, it.code)
             assertEquals("2", it.header("X-Lk-Mock-Region"))
         }
@@ -101,24 +91,24 @@ class RegionFailoverTest {
 
     @Test
     fun allUnavailable() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0,1,2,3")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0, 1, 2, 3)).use {
             assertEquals(503, it.code)
         }
     }
 
     @Test
     fun clientErrorNotRetried() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0", "X-Lk-Mock-Fail-Status" to "400")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0), "failStatus" to 400).use {
             assertEquals(400, it.code)
         }
     }
 
     @Test
     fun transportErrorFailover() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0", "X-Lk-Mock-Fail-Mode" to "drop")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0), "failMode" to "drop").use {
             assertEquals(200, it.code)
             assertEquals("1", it.header("X-Lk-Mock-Region"))
         }
@@ -126,36 +116,36 @@ class RegionFailoverTest {
 
     @Test
     fun regionDiscoveryUnreachable() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0", "X-Lk-Mock-Regions-Status" to "500")).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0), "regionsStatus" to 500).use {
             assertEquals(503, it.code)
         }
     }
 
     @Test
     fun notCloudHost() {
-        if (!serverUp()) return
+        if (!MockControl.serverUp()) return
         // Enabled but not forced; 127.0.0.1 is not a cloud host, so no failover.
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0"), force = false).use {
+        call("failRegions" to listOf(0), force = false).use {
             assertEquals(503, it.code)
         }
     }
 
     @Test
     fun disabled() {
-        if (!serverUp()) return
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0"), failover = false).use {
+        if (!MockControl.serverUp()) return
+        call("failRegions" to listOf(0), failover = false).use {
             assertEquals(503, it.code)
         }
     }
 
     @Test
     fun shortTimeoutSkipsFailover() {
-        if (!serverUp()) return
+        if (!MockControl.serverUp()) return
         // A sub-threshold per-request timeout trips the thundering-herd guard, so a
         // failing primary region collapses to a single attempt (no failover). The
         // interceptor consumes the internal timeout header before reaching the mock.
-        call(mapOf("X-Lk-Mock-Fail-Regions" to "0", "X-Lk-Request-Timeout" to "1")).use {
+        call("failRegions" to listOf(0), requestTimeout = "1").use {
             assertEquals(503, it.code)
         }
     }


### PR DESCRIPTION
- added a LiveKitAPI class to reduce overhead of accessing services
- ability to use token based auth instead of requiring API key/secret
- full api smoke tests to ensure correct token permissions, request encoding
- added SIPCallError & ServerError