### PR TITLE
server-sdk-kotlin: add unified startEgress convenience method

### DIFF
--- a/.changeset/unified-start-egress.md
+++ b/.changeset/unified-start-egress.md
@@ -1,0 +1,5 @@
+---
+"server-sdk-kotlin": minor
+---
+
+Add a unified `startEgress` method to `EgressServiceClient` that calls the v2 `Egress.StartEgress` RPC.

--- a/src/main/kotlin/io/livekit/server/EgressService.kt
+++ b/src/main/kotlin/io/livekit/server/EgressService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,13 @@ import retrofit2.http.POST
  * Retrofit Interface for accessing the EgressService Apis.
  */
 interface EgressService {
+
+    @Headers("Content-Type: application/protobuf")
+    @POST("/twirp/livekit.Egress/StartEgress")
+    fun startEgress(
+        @Body request: LivekitEgress.StartEgressRequest,
+        @Header("Authorization") authorization: String
+    ): Call<LivekitEgress.EgressInfo>
 
     @Headers("Content-Type: application/protobuf")
     @POST("/twirp/livekit.Egress/StartRoomCompositeEgress")

--- a/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
+++ b/src/main/kotlin/io/livekit/server/EgressServiceClient.kt
@@ -22,6 +22,7 @@ import io.livekit.server.okhttp.OkHttpHolder
 import io.livekit.server.okhttp.RegionFailoverInterceptor
 import io.livekit.server.retrofit.TransformCall
 import livekit.LivekitEgress
+import livekit.LivekitModels
 import okhttp3.OkHttpClient
 import retrofit2.Call
 import retrofit2.Retrofit
@@ -52,6 +53,103 @@ class EgressServiceClient(
     private val secret: String,
     private val token: String? = null,
 ) {
+
+    @JvmOverloads
+    fun startEgress(
+        roomName: String,
+        template: LivekitEgress.TemplateSource,
+        outputs: List<LivekitEgress.Output>,
+        optionsPreset: LivekitEgress.EncodingOptionsPreset? = null,
+        optionsAdvanced: LivekitEgress.EncodingOptions? = null,
+        storage: LivekitEgress.StorageConfig? = null,
+        webhooks: List<LivekitModels.WebhookConfig> = emptyList(),
+    ): Call<LivekitEgress.EgressInfo> {
+        val requestBuilder = LivekitEgress.StartEgressRequest.newBuilder()
+            .setTemplate(template)
+        return startEgressImpl(
+            requestBuilder,
+            roomName,
+            outputs,
+            optionsPreset,
+            optionsAdvanced,
+            storage,
+            webhooks,
+        )
+    }
+
+    @JvmOverloads
+    fun startEgress(
+        roomName: String,
+        web: LivekitEgress.WebSource,
+        outputs: List<LivekitEgress.Output>,
+        optionsPreset: LivekitEgress.EncodingOptionsPreset? = null,
+        optionsAdvanced: LivekitEgress.EncodingOptions? = null,
+        storage: LivekitEgress.StorageConfig? = null,
+        webhooks: List<LivekitModels.WebhookConfig> = emptyList(),
+    ): Call<LivekitEgress.EgressInfo> {
+        val requestBuilder = LivekitEgress.StartEgressRequest.newBuilder()
+            .setWeb(web)
+        return startEgressImpl(
+            requestBuilder,
+            roomName,
+            outputs,
+            optionsPreset,
+            optionsAdvanced,
+            storage,
+            webhooks,
+        )
+    }
+
+    @JvmOverloads
+    fun startEgress(
+        roomName: String,
+        media: LivekitEgress.MediaSource,
+        outputs: List<LivekitEgress.Output>,
+        optionsPreset: LivekitEgress.EncodingOptionsPreset? = null,
+        optionsAdvanced: LivekitEgress.EncodingOptions? = null,
+        storage: LivekitEgress.StorageConfig? = null,
+        webhooks: List<LivekitModels.WebhookConfig> = emptyList(),
+    ): Call<LivekitEgress.EgressInfo> {
+        val requestBuilder = LivekitEgress.StartEgressRequest.newBuilder()
+            .setMedia(media)
+        return startEgressImpl(
+            requestBuilder,
+            roomName,
+            outputs,
+            optionsPreset,
+            optionsAdvanced,
+            storage,
+            webhooks,
+        )
+    }
+
+    private fun startEgressImpl(
+        requestBuilder: LivekitEgress.StartEgressRequest.Builder,
+        roomName: String,
+        outputs: List<LivekitEgress.Output>,
+        optionsPreset: LivekitEgress.EncodingOptionsPreset?,
+        optionsAdvanced: LivekitEgress.EncodingOptions?,
+        storage: LivekitEgress.StorageConfig?,
+        webhooks: List<LivekitModels.WebhookConfig>,
+    ): Call<LivekitEgress.EgressInfo> {
+        val request = with(requestBuilder) {
+            this.roomName = roomName
+            addAllOutputs(outputs)
+            if (optionsPreset != null) {
+                this.preset = optionsPreset
+            } else if (optionsAdvanced != null) {
+                this.advanced = optionsAdvanced
+            }
+            if (storage != null) {
+                this.storage = storage
+            }
+            addAllWebhooks(webhooks)
+            build()
+        }
+        val credentials = authHeader(RoomRecord(true))
+
+        return service.startEgress(request, credentials)
+    }
 
     @JvmOverloads
     fun startRoomCompositeEgress(

--- a/src/test/kotlin/io/livekit/server/EgressServiceClientTest.kt
+++ b/src/test/kotlin/io/livekit/server/EgressServiceClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package io.livekit.server
 
 import io.livekit.server.okhttp.OkHttpFactory
 import livekit.LivekitEgress
+import livekit.LivekitModels
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -182,6 +183,61 @@ class EgressServiceClientTest {
         client.startWebEgress(
             url = "http://www.example.com",
             output = DEFAULT_OUTPUTS,
+        )
+    }
+
+    @Test
+    fun startEgressTemplate() {
+        client.startEgress(
+            roomName = "room",
+            template = LivekitEgress.TemplateSource.getDefaultInstance(),
+            outputs = listOf(
+                LivekitEgress.Output.newBuilder()
+                    .setFile(LivekitEgress.FileOutput.getDefaultInstance())
+                    .build(),
+            ),
+        )
+    }
+
+    @Test
+    fun startEgressWeb() {
+        client.startEgress(
+            roomName = "room",
+            web = LivekitEgress.WebSource.getDefaultInstance(),
+            outputs = listOf(
+                LivekitEgress.Output.newBuilder()
+                    .setStream(LivekitEgress.StreamOutput.getDefaultInstance())
+                    .build(),
+            ),
+        )
+    }
+
+    @Test
+    fun startEgressMedia() {
+        client.startEgress(
+            roomName = "room",
+            media = LivekitEgress.MediaSource.getDefaultInstance(),
+            outputs = listOf(
+                LivekitEgress.Output.newBuilder()
+                    .setFile(LivekitEgress.FileOutput.getDefaultInstance())
+                    .build(),
+            ),
+        )
+    }
+
+    @Test
+    fun startEgressWithOptionsStorageAndWebhooks() {
+        client.startEgress(
+            roomName = "room",
+            media = LivekitEgress.MediaSource.getDefaultInstance(),
+            outputs = listOf(
+                LivekitEgress.Output.newBuilder()
+                    .setFile(LivekitEgress.FileOutput.getDefaultInstance())
+                    .build(),
+            ),
+            optionsAdvanced = LivekitEgress.EncodingOptions.getDefaultInstance(),
+            storage = LivekitEgress.StorageConfig.getDefaultInstance(),
+            webhooks = listOf(LivekitModels.WebhookConfig.getDefaultInstance()),
         )
     }
 }


### PR DESCRIPTION
server-sdk-kotlin's EgressServiceClient exposes a unified startEgress that calls the Egress.StartEgress RPC with the v2 StartEgressRequest.
