### PR TITLE
Require exp when verifying webhook JWTs

### DIFF
--- a/.changeset/webhook-require-exp.md
+++ b/.changeset/webhook-require-exp.md
@@ -1,0 +1,5 @@
+---
+"server-sdk-kotlin": patch
+---
+
+WebhookReceiver requires the JWT exp claim. java-jwt accepts a signed token with no expiry unless presence is required.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
       run: ./gradlew assemble
 
     - name: Run unit tests (no livekit-server integration tests)
-      run: ./gradlew test --tests "io.livekit.server.AccessTokenTest"
+      run: ./gradlew test --tests "io.livekit.server.AccessTokenTest" --tests "io.livekit.server.WebhookReceiverTest"
 
     - name: get version name
       if: github.event_name == 'push'

--- a/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
+++ b/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
@@ -17,6 +17,7 @@
 package io.livekit.server
 
 import com.auth0.jwt.JWT
+import com.auth0.jwt.RegisteredClaims
 import com.auth0.jwt.algorithms.Algorithm
 import com.google.protobuf.util.JsonFormat
 import livekit.LivekitWebhook
@@ -42,7 +43,7 @@ class WebhookReceiver(
             val alg = Algorithm.HMAC256(secret)
             val decodedJWT = JWT.require(alg)
                 .withIssuer(apiKey)
-                .withClaimPresence("exp")
+                .withClaimPresence(RegisteredClaims.EXPIRES_AT)
                 .build()
                 .verify(authHeader)
 

--- a/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
+++ b/src/main/kotlin/io/livekit/server/WebhookReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class WebhookReceiver(
             val alg = Algorithm.HMAC256(secret)
             val decodedJWT = JWT.require(alg)
                 .withIssuer(apiKey)
+                .withClaimPresence("exp")
                 .build()
                 .verify(authHeader)
 

--- a/src/test/kotlin/io/livekit/server/WebhookReceiverTest.kt
+++ b/src/test/kotlin/io/livekit/server/WebhookReceiverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LiveKit, Inc.
+ * Copyright 2024-2026 LiveKit, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package io.livekit.server
 
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.MissingClaimException
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class WebhookReceiverTest {
 
@@ -40,5 +44,27 @@ class WebhookReceiverTest {
 
         assertEquals("mytestroom", event.room.name)
         assertEquals("room_started", event.event)
+    }
+
+    @Test
+    fun receiveRejectsTokenWithoutExp() {
+        val body =
+            """{"event":"room_started", "room":{"sid":"RM_TkVjUvAqgzKz", "name":"mytestroom", 
+                |"emptyTimeout":300, "creationTime":"1628545903", "turnPassword":"ICkSr2rEeslkN6e9bXL4Ji5zzMD5Z7zzr6ulOaxMj6N", 
+                |"enabledCodecs":[{"mime":"audio/opus"}, {"mime":"video/VP8"}]}}""".trimMargin()
+        val testApiKey = "abcdefg"
+        val testSecret = "ababababababababababababababababababababababababababababababa"
+
+        // java-jwt 4.x treats a missing exp as valid unless presence is required.
+        val jwt = JWT.create()
+            .withIssuer(testApiKey)
+            .withClaim("sha256", "1renMMRYeCXsy6M9bjJ90XA3M1q1byhUGNoD91aPuhM=")
+            .sign(Algorithm.HMAC256(testSecret))
+
+        val receiver = WebhookReceiver(testApiKey, testSecret)
+
+        assertFailsWith<MissingClaimException> {
+            receiver.receive(body, jwt)
+        }
     }
 }


### PR DESCRIPTION
## Problem

`WebhookReceiver.receive` verifies the webhook JWT with `JWT.require(alg).withIssuer(apiKey)` only. java-jwt 4.x treats a missing `exp` as valid (`claimVal == null` passes the expiry check) unless `withClaimPresence("exp")` is set, so a hand-rolled token with a valid HMAC and no expiry verifies forever.

First-party `AccessToken.toJwt` always sets `exp`. This is the same gap livekit/protocol#1706 closed on the Go verifier, livekit/python-sdks#779 on Python, livekit/node-sdks#710 on Node, and livekit/server-sdk-ruby#97 on Ruby. This repo has no `TokenVerifier`; `WebhookReceiver` is the verify path.

## Fix

Require the `exp` claim on verify.

Threat-model: the attacker can mint or obtain an HS256 token that omits `exp`. They do not control the verifier secret or clock. Signature verification still succeeds and the credential never ages out. That is permanent access from a forgotten expiry, not host or agent authority.

## Test plan

- [x] `./gradlew test --tests io.livekit.server.AccessTokenTest --tests io.livekit.server.WebhookReceiverTest` (5/5)
- [x] New case: signed token with no `exp` raises `MissingClaimException`
- [x] Revert-test: drop `withClaimPresence("exp")` and that case fails (token is accepted)
- [x] CI also runs `WebhookReceiverTest` so the new case is not AccessToken-only

Made with [Cursor](https://cursor.com)