### PR TITLE
Update java-jwt and jackson-databind

### DIFF
--- a/.changeset/plenty-hats-rescue.md
+++ b/.changeset/plenty-hats-rescue.md
@@ -1,0 +1,12 @@
+---
+"server-sdk-kotlin": patch
+---
+
+Update com.auth0:java-jwt to 4.6.0 and com.fasterxml.jackson.core:jackson-databind to 2.22.2
+
+There were vulnerabilities found effective previous versions of jackson-databind. This update
+resolves those.
+
+See:
+CVE-2026-54515
+CVE-2026-59889

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.proto
+import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
@@ -191,7 +191,8 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor")
     api("com.squareup.retrofit2:retrofit:3.0.0")
     implementation("com.squareup.retrofit2:converter-protobuf:3.0.0")
-    implementation("com.auth0:java-jwt:4.5.1")
+    implementation("com.auth0:java-jwt:4.6.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.22.2")
     api(protobufDep)
     api("com.google.protobuf:protobuf-java-util:$protobufVersion")
     implementation("javax.annotation:javax.annotation-api:1.3.2")


### PR DESCRIPTION
There were vulnerabilities found effective previous versions of jackson-databind. This update resolves those.

See:
CVE-2026-54515
CVE-2026-59889